### PR TITLE
Switch Payload database to Supabase Postgres

### DIFF
--- a/to-workstream-dashboard-payload/.env.example
+++ b/to-workstream-dashboard-payload/.env.example
@@ -1,8 +1,6 @@
 # Database connection string
-DATABASE_URI=mongodb://127.0.0.1/your-database-name
-
-# Or use a PG connection string
-#DATABASE_URI=postgresql://127.0.0.1:5432/your-database-name
+# Provide your Supabase Postgres URL (including password)
+DATABASE_URI=postgresql://USER:PASSWORD@HOST.supabase.co:5432/postgres?sslmode=require
 
 # Used to encrypt JWT tokens
 PAYLOAD_SECRET=YOUR_SECRET_HERE

--- a/to-workstream-dashboard-payload/docker-compose.yml
+++ b/to-workstream-dashboard-payload/docker-compose.yml
@@ -9,23 +9,9 @@ services:
       - .:/home/node/app
       - node_modules:/home/node/app/node_modules
     working_dir: /home/node/app/
-    command: sh -c "yarn install && yarn dev"
-    depends_on:
-      - mongo
+    command: sh -c "pnpm install && pnpm dev"
     env_file:
       - .env
 
-  mongo:
-    image: mongo:latest
-    ports:
-      - '27017:27017'
-    command:
-      - --storageEngine=wiredTiger
-    volumes:
-      - data:/data/db
-    logging:
-      driver: none
-
 volumes:
-  data:
   node_modules:

--- a/to-workstream-dashboard-payload/package.json
+++ b/to-workstream-dashboard-payload/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@payloadcms/admin-bar": "3.48.0",
-    "@payloadcms/db-mongodb": "3.48.0",
+    "@payloadcms/db-postgres": "3.48.0",
     "@payloadcms/live-preview-react": "3.48.0",
     "@payloadcms/next": "3.48.0",
     "@payloadcms/payload-cloud": "3.48.0",

--- a/to-workstream-dashboard-payload/src/payload.config.ts
+++ b/to-workstream-dashboard-payload/src/payload.config.ts
@@ -1,5 +1,5 @@
 // storage-adapter-import-placeholder
-import { mongooseAdapter } from '@payloadcms/db-mongodb'
+import { postgresAdapter } from '@payloadcms/db-postgres'
 
 import sharp from 'sharp' // sharp-import
 import path from 'path'
@@ -59,8 +59,13 @@ export default buildConfig({
   },
   // This config helps us configure global or default features that the other editors can inherit
   editor: defaultLexical,
-  db: mongooseAdapter({
-    url: process.env.DATABASE_URI || '',
+  db: postgresAdapter({
+    pool: {
+      connectionString: process.env.DATABASE_URI ?? '',
+      ssl: {
+        rejectUnauthorized: false,
+      },
+    },
   }),
   collections: [Pages, Posts, Media, Categories, Users],
   cors: [getServerSideURL()].filter(Boolean),


### PR DESCRIPTION
## Summary
- replace the MongoDB database dependency with the Postgres adapter and configure Payload to use the Supabase connection string with SSL
- refresh the example environment variables and docker-compose setup to align with a Supabase-hosted Postgres database

## Testing
- pnpm install *(fails: 403 Forbidden when downloading @tailwindcss/typography from the npm registry)*
- pnpm payload *(fails: cross-env binary missing because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d78784ec7c832f996f18469341fc4d